### PR TITLE
Run dontstarve server on an unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN dpkg --add-architecture i386 \
      && apt-get clean -y \
      && rm -rf /var/lib/apt/lists/*
 
+# Add unprivileged user
+RUN groupadd dst && useradd -g dst -d /home/dst dst
+
 # install steamcmd
 RUN mkdir -p /opt/steamcmd \
     && wget "${STEAMCMD_URL}" -O /tmp/steamcmd.tar.gz \
@@ -29,9 +32,7 @@ COPY install_dst_server_initial /opt/steamcmd_scripts/
 RUN chmod +x /entrypoint.sh /healthcheck.sh /usr/local/bin/steamcmd /usr/local/bin/dontstarve_dedicated_server_nullrenderer
 
 # create data directory
-# dst server seems to be ignoring `-persistent_storage_root` argument, let's workaround it too
-RUN mkdir -p /data \
-    && ln -s /data ${HOME}/.klei
+RUN mkdir -p /data
 
 # install Don't Starve Together server
 RUN mkdir -p /opt/dst_server \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ if [ "$1" == "dontstarve_dedicated_server_nullrenderer" -o "$1" == "supervisord"
         echo "Creating default server config..."
         cp -r /opt/dst_default_config/* /data
         touch /data/DoNotStarveTogether/Cluster_1/cluster_token.txt
+        chown -R dst:dst /data/*
         echo "Done, please fill in \`DoNotStarveTogether/Cluster_1/cluster_token.txt\` with your cluster token and restart server!"
         exit
     fi
@@ -43,7 +44,7 @@ if [ "$1" == "dontstarve_dedicated_server_nullrenderer" -o "$1" == "supervisord"
     echo "Updating server..."
     steamcmd +runscript /opt/steamcmd_scripts/install_dst_server
     echo "Updating mods..."
-    dontstarve_dedicated_server_nullrenderer -only_update_server_mods
+    su - dst -c "dontstarve_dedicated_server_nullrenderer -persistent_storage_root /data -only_update_server_mods"
 
     # create unix socks server for supervisor
     touch /var/run/supervisor.sock

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -11,7 +11,8 @@ supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///var/run/supervisor.sock
 
 [program:dst-server-master]
-command=dontstarve_dedicated_server_nullrenderer -shard Master
+user=dst
+command=dontstarve_dedicated_server_nullrenderer -persistent_storage_root /data -shard Master
 startsecs=5
 startretries=0
 autorestart=unexpected
@@ -23,7 +24,8 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 
 [program:dst-server-cave]
-command=dontstarve_dedicated_server_nullrenderer -shard Caves
+user=dst
+command=dontstarve_dedicated_server_nullrenderer -persistent_storage_root /data -shard Caves
 startsecs=5
 startretries=0
 autorestart=unexpected


### PR DESCRIPTION
Adds an unprivileged user to the container to run the server instances in.

Running as non-root user helps mitigating capabilities to take over the host system in case someone manages to successfully exploit the dont starve server