### PR TITLE
rebase image on cm2network/steamcmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM steamcmd/steamcmd:ubuntu
+FROM cm2network/steamcmd:root
 LABEL maintainer="James Swineson <docker@public.swineson.me>"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -6,19 +6,16 @@ ARG LANG=C.UTF-8
 ARG LC_ALL=C.UTF-8
 
 # install packages
-# why libcurl-gnutls.so.4 in Ubuntu is packages in libcurl3-gnutls
-RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends libcurl3-gnutls:i386 supervisor \
+RUN dpkg --add-architecture i386 \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends libcurl4-gnutls-dev:i386 supervisor \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
 # create data directory
 RUN mkdir -p /data \
-# Add unprivileged user
-    && groupadd dst \
-    && useradd -g dst -d /data dst \
-    && chown -R dst:dst /data
+    && chown -R steam:steam /data
 
 # install helper tools
 COPY supervisor /etc/supervisor/
@@ -28,12 +25,13 @@ RUN chmod +x /usr/local/bin/*
 
 # install Don't Starve Together server
 RUN mkdir -p /opt/dst_server \
+    && chown steam:steam /opt/dst_server \
     && steamcmd +runscript /opt/steamcmd_scripts/install_dst_server_initial \
     && rm -rf /root/Steam /root/.steam
 
 # install default config
 COPY dst_default_config /opt/dst_default_config/
-RUN chown -R dst:dst /opt/dst_default_config
+RUN chown -R steam:steam /opt/dst_default_config
 
 VOLUME [ "/data" ]
 

--- a/scripts_system/entrypoint.sh
+++ b/scripts_system/entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$1" == "dontstarve_dedicated_server_nullrenderer" -o "$1" == "supervisord"
         echo "Creating default server config..."
         cp -r /opt/dst_default_config/* /data
         touch /data/DoNotStarveTogether/Cluster_1/cluster_token.txt
-        chown -R dst:dst /data
+        chown -R steam:steam /data
         echo "Done, please fill in \`DoNotStarveTogether/Cluster_1/cluster_token.txt\` with your cluster token and restart server!"
         exit
     fi
@@ -41,13 +41,13 @@ if [ "$1" == "dontstarve_dedicated_server_nullrenderer" -o "$1" == "supervisord"
     fi
 
     # fix permission
-    chown -R dst:dst /data
+    chown -R steam:steam /data
 
     # Update game
     echo "Updating server..."
     steamcmd +runscript /opt/steamcmd_scripts/install_dst_server
     echo "Updating mods..."
-    su - dst -c "dontstarve_dedicated_server_nullrenderer -persistent_storage_root /data -only_update_server_mods"
+    su - steam -c "dontstarve_dedicated_server_nullrenderer -persistent_storage_root /data -only_update_server_mods"
 
     # create unix socks server for supervisor
     touch /var/run/supervisor.sock

--- a/scripts_system/steamcmd
+++ b/scripts_system/steamcmd
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+
+exec /home/steam/steamcmd/steamcmd.sh "${@:1}"

--- a/supervisor/supervisor.conf
+++ b/supervisor/supervisor.conf
@@ -11,7 +11,7 @@ supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///var/run/supervisor.sock
 
 [program:dst-server-master]
-user=dst
+user=steam
 command=dontstarve_dedicated_server_nullrenderer -persistent_storage_root /data -shard Master
 startsecs=40
 startretries=0
@@ -24,7 +24,7 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 
 [program:dst-server-cave]
-user=dst
+user=steam
 command=dontstarve_dedicated_server_nullrenderer -persistent_storage_root /data -shard Caves
 startsecs=40
 startretries=0


### PR DESCRIPTION
Fixes #21 
I've tested on my vps. Althouth there were some assertion failures, dst server was finally started.
```
[00:00:21]: [Steam] SteamGameServer_Init(8767, 11000, 12347)
CAppInfoCacheReadFromDiskThread took 0 milliseconds to initialize
applicationmanager.cpp (3881) : Assertion Failed: CApplicationManager::GetMountVolume: invalid index
applicationmanager.cpp (3881) : Assertion Failed: CApplicationManager::GetMountVolume: invalid index
applicationmanager.cpp (3881) : Assertion Failed: CApplicationManager::GetMountVolume: invalid index
applicationmanager.cpp (3881) : Assertion Failed: CApplicationManager::GetMountVolume: invalid index
applicationmanager.cpp (4044) : Assertion Failed: m_vecInstallBaseFolders.Count() > 0
CApplicationManagerPopulateThread took 14 milliseconds to initialize (will have waited on CAppInfoCacheReadFromDiskThread)
Setting breakpad minidump AppID = 322330
applicationmanager.cpp (4044) : Assertion Failed: m_vecInstallBaseFolders.Count() > 0
[00:00:21]: [Steam] SteamGameServer_Init success
[00:00:21]: [Shard] Sending slave information to master...
```