### PR TITLE
Fixed docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
+version: '3.5'
 services:
   dst-server:
      image: jamesits/dst-server:latest
-     deploy:
-         restart_policy:
-             condition: on-failure
+     restart: "on-failure:5"
      ports:
         - "10999-11000:10999-11000/udp"
         - "12346-12347:12346-12347/udp"


### PR DESCRIPTION
The current docker-compose file gives an error 
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services: 'dst-server'
```

It's obviously missing the version, and I don't know about restart policy, but i've changed this parameter according to one of my docker-compose files as well. Now it's working properly.