### PR TITLE
Update entrypoint.sh for better PaaS integration

### DIFF
--- a/scripts_system/entrypoint.sh
+++ b/scripts_system/entrypoint.sh
@@ -59,6 +59,9 @@ if [ "$1" == "dontstarve_dedicated_server_nullrenderer" ] || [ "$1" == "supervis
     echo "Updating mods..."
     su --login --group "${DST_GROUP}" -c "dontstarve_dedicated_server_nullrenderer -persistent_storage_root \"${DST_USER_DATA_PATH}\" -only_update_server_mods" "${DST_USER}"
 
+    # remove any preexistent supervisor socket 
+    rm /var/run/supervisor.sock
+    
     # create unix socks server for supervisor
     touch /var/run/supervisor.sock
 fi

--- a/scripts_system/entrypoint.sh
+++ b/scripts_system/entrypoint.sh
@@ -60,7 +60,7 @@ if [ "$1" == "dontstarve_dedicated_server_nullrenderer" ] || [ "$1" == "supervis
     su --login --group "${DST_GROUP}" -c "dontstarve_dedicated_server_nullrenderer -persistent_storage_root \"${DST_USER_DATA_PATH}\" -only_update_server_mods" "${DST_USER}"
 
     # remove any preexistent supervisor socket 
-    rm /var/run/supervisor.sock
+    rm -f /var/run/supervisor.sock
     
     # create unix socks server for supervisor
     touch /var/run/supervisor.sock


### PR DESCRIPTION
When using a PaaS such as Jelastic, if the `/data` folder is bound to the local system, it is possible that the PaaS will put the file back here when redeploying or restarting. The `touch` command does nothing if the file already exists, and `supervisord` throw an exception: `Error: Another program is already listening on a port that one of our HTTP servers is configured to use.  Shut this program down first before starting supervisord.` By removing the file first, the problem is solved.