### PR TITLE
add ugc_directory option so that new v2(ugc) mods are stored with user data

### DIFF
--- a/scripts_system/entrypoint.sh
+++ b/scripts_system/entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" == "dontstarve_dedicated_server_nullrenderer" ] || [ "$1" == "supervis
 
     # fix config file permission
     chown -R "${DST_USER}:${DST_GROUP}" "${DST_USER_DATA_PATH}"
-    
+
     # protect our mods dir
     # if the mods dir is already a symlink, then we temporary remove it to protect it, so that it survives a container restart
     if [[ -L "${DIR_MODS_SYS}" ]]; then
@@ -68,11 +68,11 @@ if [ "$1" == "dontstarve_dedicated_server_nullrenderer" ] || [ "$1" == "supervis
 
     # update mods
     echo "Updating mods..."
-    su --login --group "${DST_GROUP}" -c "dontstarve_dedicated_server_nullrenderer -persistent_storage_root \"${DST_USER_DATA_PATH}\" -only_update_server_mods" "${DST_USER}"
+    su --login --group "${DST_GROUP}" -c "dontstarve_dedicated_server_nullrenderer -persistent_storage_root \"${DST_USER_DATA_PATH}\" -ugc_directory \"${DST_USER_DATA_PATH}\"/ugc -only_update_server_mods" "${DST_USER}"
 
     # remove any existing supervisor socket
     rm -f /var/run/supervisor.sock
-    
+
     # create the unix socket file for supervisor
     touch /var/run/supervisor.sock
 fi

--- a/supervisor/supervisor.conf
+++ b/supervisor/supervisor.conf
@@ -16,7 +16,7 @@ serverurl=unix:///var/run/supervisor.sock
 [program:dst-server-master]
 user=%(ENV_DST_USER)s
 group=%(ENV_DST_GROUP)s
-command=dontstarve_dedicated_server_nullrenderer -persistent_storage_root %(ENV_DST_USER_DATA_PATH)s -shard Master
+command=dontstarve_dedicated_server_nullrenderer -persistent_storage_root %(ENV_DST_USER_DATA_PATH)s -ugc_directory %(ENV_DST_USER_DATA_PATH)s/ugc -shard Master
 startsecs=40
 startretries=0
 autorestart=unexpected
@@ -30,7 +30,7 @@ stderr_logfile_maxbytes=0
 [program:dst-server-cave]
 user=%(ENV_DST_USER)s
 group=%(ENV_DST_GROUP)s
-command=dontstarve_dedicated_server_nullrenderer -persistent_storage_root %(ENV_DST_USER_DATA_PATH)s -shard Caves
+command=dontstarve_dedicated_server_nullrenderer -persistent_storage_root %(ENV_DST_USER_DATA_PATH)s -ugc_directory %(ENV_DST_USER_DATA_PATH)s/ugc -shard Caves
 startsecs=40
 startretries=0
 autorestart=unexpected


### PR DESCRIPTION
The March QoL update adopted a new approach to mods.  It now uses a different Steam API to pull in mods and they end up being downloaded to a different directory.

For me this was causing the image to run out of internal space.  It also meant that any Mod updated after roughly March 14th would break the server startup by failing to download in some cases.

### The following threads are informative on the change (though not on how they apply in docker):

https://forums.kleientertainment.com/forums/topic/128188-what-is-ugc/?tab=comments#comment-1440371

https://forums.kleientertainment.com/forums/topic/128054-questions-regarding-mod-management-post-qol/?tab=comments#comment-1440200

### this change

Utilizes the existing `/data` mount and stores the new mods in `/data/ugc`
Klei added a new option `-ugc_directory` which is used for this purpose.

I've tested this as working with my own server so far.  I can see the mods downloaded to the directory I map to data within the `ugc` subdirectory.  The server starts, and mod in question now works.  


### Open questions

There's a fair bit of discussion in entrypoint.sh about shuffling the mods directory around so its not exposed to a server update.  It's unclear to me if the same needs to happen for ugc (v2) mods or not.  I believe that they are now pulled by steam rather than DST itself, so they may be immune to the DST update wiping them out.