### PR TITLE
updated dockerfile to use supervisor config from mounted path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,5 +62,5 @@ VOLUME [ "${DST_USER_DATA_PATH}" ]
 
 EXPOSE 10999-11000/udp 12346-12347/udp
 ENTRYPOINT [ "entrypoint.sh" ]
-CMD ["supervisord", "-c", "/etc/supervisor/supervisor.conf", "-n"]
+CMD ["supervisord", "-c", "/data/supervisor/supervisor.conf", "-n"]
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 CMD [ "healthcheck.sh" ]


### PR DESCRIPTION
Unfortunately this is a bit of a hack :(
I am not very familiar with docker so I could not find a way to use the DST_USER_DATA_PATH environment variable for this purpose.

This change allows me to manipulate the supervisor.conf in the mounted volume to adopt changes if needed for multiple worlds.