### PR TITLE
Adding Caves related issues to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,25 @@ The server will create a cave for you. If you don't want the cave, you have to m
 Open `Cluster_X/Master/modoverrides.lua` and you will see something like `workshop-XXXXX` where `XXXXX` is a number.\
 Open `Cluster_1/mods/dedicated_server_mods_setup.lua` on server and write `ServerModSetup("XXXXX")`.
 
+
+#### My server goes up with no Caves
+Verify the content of `Cluster_1/Caves/server.ini` and `Cluster_1/Master/server.ini`.
+If they are different from [this](https://github.com/renie/docker-dst-server/blob/master/dst_default_config/DoNotStarveTogether/Cluster_1/Caves/server.ini) and [this](https://github.com/renie/docker-dst-server/blob/master/dst_default_config/DoNotStarveTogether/Cluster_1/Master/server.ini) files respectively, replace the content of your files by the ones from this repo.
+
+#### My Caves are loading as another Forest
+Try using the settings file of a regular server on your host this way:
+
+- Host server within the game itself (not a dedicated one)
+- Add caves and do anything else you might want in the world generation
+- Let the game generate the world for you
+- When you get to the screen to choose a character, close the game
+- Go to the DST folder of the regular game `Klei\DoNotStarveTogether`
+- Find the game you have just created
+  - To do this, open your clusters folders and check the `cluster.ini` files until you find a server with the name of the server you have just created
+- Open the `Caves` folder
+- Copy the file `leveldataoverride.lua` to your dedicated server under `Cluster_1/Caves`
+
+
 ## Maintainer
 
  * [James Swineson](https://swineson.me)


### PR DESCRIPTION
I've had some issues while running the container using docker-compose.

First the Caves won't go up at all. Logs mentioned `SOCKET_PORT_ALREADY_IN_USE`, what is quite strange for a container. So I've noticed both my `server.ini` files, Caves and Master, did not have all the setting present on the repo's default config folder.
After copying those files from the repo to my server, that message was gone.

But now my server was going up with 2 florests, instead of a florest and a cave. So I've created a server on the game itself, copied `leveldataoverride.lua` to my dedicated server, and that is it. Server working like a charm.

I am not sure about why those original `server.ini` were different from repo's ones. Docker files and scripts sounded ok to me. I could not find a place where the content of those files were being replaced with `sed`, `awk`, or something like that. Also I do not know why caves had no `leveldataoverride.lua` and are still working for some people.

So as I could not really solve the issue, I think it would be nice to have those issues covered somehow until the problems are really solved. Even after it gets solved, I believe it would be nice to have it on FAQ just in case.

With all of that said. Thank you very much for this docker image. Klei's documentation is terrible indeed, I totally agree with you. You deserve a place in haven for saving people so much time and preventing headaches + gastritis.